### PR TITLE
InsertTimestamps.plugin.js: Set current datetime as default value

### DIFF
--- a/Plugins/InsertTimestamps/InsertTimestamps.plugin.js
+++ b/Plugins/InsertTimestamps/InsertTimestamps.plugin.js
@@ -33,7 +33,8 @@ var ButtonClasses = BdApi.Webpack.getByKeys("emojiButton", "stickerButton");
 var cl = (...names) => names.map((n) => `vbd-its-${n}`).join(" ");
 var Formats = ["", "t", "T", "d", "D", "f", "F", "R"];
 function PickerModal({ rootProps }) {
-  const [value, setValue] = useState();
+  //Credit: https://stackoverflow.com/a/62845336 for time conversion
+  const [value, setValue] = useState(() => new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 16));
   const [format, setFormat] = useState("");
   const time = Math.round((new Date(value).getTime() || Date.now()) / 1e3);
   const formatTimestamp = (time2, format2) => `<t:${time2}${format2 && `:${format2}`}>`;


### PR DESCRIPTION
Updated to have the default value set upon opening as the current time and date.